### PR TITLE
add cdc debug option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(${PROJECT_NAME}
     targets/xboxog_descriptors.c
     targets/xboxog_tusb_driver.c
     targets/xboxog.c
+    targets/usb_descriptors.c
 
     handlers/__handlers.c
     handlers/ds3.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(${PROJECT_NAME}
     xinput_host
     hardware_i2c
     i2c_slave
+    pico_unique_id
 )
 
 # auto versioning

--- a/debug.c
+++ b/debug.c
@@ -55,10 +55,19 @@ void DebugPrintf(const char *fmt, ...)
   va_list args;
   va_start(args, fmt);
 
-  vsprintf(uart_output, fmt, args);
+  int size = vsprintf(uart_output, fmt, args);
 
   uart_puts(DEBUG_UART_SLOT, uart_output);
   uart_puts(DEBUG_UART_SLOT, END_LINE);
+
+#if ENABLE_CDC_DEBUG
+  if (tud_cdc_connected())
+  {
+    tud_cdc_write(uart_output, size);
+    tud_cdc_write(END_LINE, 2);
+    tud_cdc_write_flush();
+  }
+#endif
 
   va_end(args);
 }
@@ -76,12 +85,27 @@ void DebugOutputBuffer(const char *prefix, uint8_t buff[], int len)
 
   for (int i = 0; i != len; i++)
   {
-    sprintf(uart_output, "%02X ", buff[i]);
+    int size = sprintf(uart_output, "%02X ", buff[i]);
 
     uart_puts(DEBUG_UART_SLOT, uart_output);
+
+#if ENABLE_CDC_DEBUG
+    if (tud_cdc_connected())
+    {
+      tud_cdc_write(uart_output, size);
+    }
+#endif
   }
 
   uart_puts(DEBUG_UART_SLOT, END_LINE);
+
+#if ENABLE_CDC_DEBUG
+  if (tud_cdc_connected())
+  {
+    tud_cdc_write(END_LINE, 2);
+    tud_cdc_write_flush();
+  }
+#endif
 }
 #endif
 

--- a/debug.c
+++ b/debug.c
@@ -114,9 +114,16 @@ int DebugTinyUSBPrintf(const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  vsprintf(uart_output, fmt, args);
+  int size = vsprintf(uart_output, fmt, args);
 
   uart_puts(DEBUG_UART_SLOT, uart_output);
+
+#if ENABLE_CDC_DEBUG
+  if (tud_cdc_connected())
+  {
+    tud_cdc_write(uart_output, size);
+  }
+#endif
 
   va_end(args);
 

--- a/debug.h
+++ b/debug.h
@@ -6,11 +6,11 @@
 #include <stdarg.h>
 #include "version.h"
 
-#define ENABLE_CDC_DEBUG false
-
 #define ENABLE_DEBUG_UART false
 #define ENABLE_BUFFER_DUMP false
 #define ENABLE_REPORT_DUMP false
+
+#define ENABLE_CDC_DEBUG false
 
 #define DEBUG_MIRROR_HELPER false
 

--- a/debug.h
+++ b/debug.h
@@ -6,6 +6,8 @@
 #include <stdarg.h>
 #include "version.h"
 
+#define ENABLE_CDC_DEBUG false
+
 #define ENABLE_DEBUG_UART false
 #define ENABLE_BUFFER_DUMP false
 #define ENABLE_REPORT_DUMP false

--- a/targets/usb_descriptors.c
+++ b/targets/usb_descriptors.c
@@ -1,0 +1,62 @@
+#include "tusb.h"
+#include "xboxog_descriptors.h"
+
+// Invoked when received GET DEVICE DESCRIPTOR
+// Application return pointer to descriptor
+uint8_t const *tud_descriptor_device_cb(void)
+{
+    return (uint8_t const *)&xboxog_desc_device;
+}
+
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+{
+    (void)index; // for multiple configurations
+    return (uint8_t const *)&xboxog_desc_fs_configuration;
+}
+
+static uint16_t _desc_str[32 + 1];
+
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+    (void)langid;
+    size_t chr_count;
+
+    switch (index)
+    {
+    case STRID_XBOXOG_LANGID:
+        memcpy(&_desc_str[1], xboxog_string_desc_arr[0], 2);
+        chr_count = 1;
+        break;
+
+        // case STRID_SERIAL:
+        // chr_count = board_usb_get_serial(_desc_str + 1, 32);
+        // break;
+
+    default:
+        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+        if (index >= xboxog_string_desc_arr_len)
+            return NULL;
+
+        const char *str = xboxog_string_desc_arr[index];
+
+        // Cap at max char
+        chr_count = strlen(str);
+        size_t const max_count = sizeof(_desc_str) / sizeof(_desc_str[0]) - 1; // -1 for string type
+        if (chr_count > max_count)
+            chr_count = max_count;
+
+        // Convert ASCII string into UTF-16
+        for (size_t i = 0; i < chr_count; i++)
+        {
+            _desc_str[1 + i] = str[i];
+        }
+        break;
+    }
+
+    // first byte is length (including header), second byte is string type
+    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+    return _desc_str;
+}

--- a/targets/usb_descriptors.c
+++ b/targets/usb_descriptors.c
@@ -5,8 +5,8 @@
 
 #if ENABLE_CDC_DEBUG
 
-#define USB_CDC_VID 0xCafe
-#define USB_CDC_PID (0x4000)
+#define USB_CDC_VID 0xCAFE
+#define USB_CDC_PID 0x4000
 
 tusb_desc_device_t const desc_cdc_device = {
     .bLength = sizeof(tusb_desc_device_t),

--- a/targets/usb_descriptors.c
+++ b/targets/usb_descriptors.c
@@ -1,20 +1,148 @@
 #include "tusb.h"
+#include "usb_descriptors.h"
 #include "xboxog_descriptors.h"
+#include "pico/unique_id.h"
+
+#if ENABLE_CDC_DEBUG
+
+#define USB_CDC_VID 0xCafe
+#define USB_CDC_PID (0x4000)
+
+tusb_desc_device_t const desc_cdc_device = {
+    .bLength = sizeof(tusb_desc_device_t),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB = 0x0200,
+
+    // Use Interface Association Descriptor (IAD) for CDC
+    // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+    .idVendor = USB_CDC_VID,
+    .idProduct = USB_CDC_PID,
+    .bcdDevice = 0x0100,
+
+    .iManufacturer = STRID_MANUFACTURER,
+    .iProduct = STRID_DEBUG_PRODUCT,
+    .iSerialNumber = STRID_SERIAL,
+
+    .bNumConfigurations = 0x01,
+};
+
+enum
+{
+    ITF_NUM_CDC = 0,
+    ITF_NUM_CDC_DATA,
+    ITF_NUM_TOTAL
+};
+
+#define EPNUM_CDC_NOTIF 0x81
+#define EPNUM_CDC_OUT 0x02
+#define EPNUM_CDC_IN 0x82
+
+#define CONFIG_CDC_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
+
+// full speed configuration
+uint8_t const desc_fs_configuration[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, STRID_DEBUG_PRODUCT, CONFIG_CDC_TOTAL_LEN, 0x00, 100),
+
+    // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, STRID_CDC_INTERFACE, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64),
+
+};
+
+#endif
+
+// array of pointer to string descriptors
+// matches global_string_id
+char const *global_string_array[] = {
+
+    (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
+    "icedragon.io",             // 1: Manufacturer
+    "xbox og controller s",     // 2: Product
+    NULL,                       // 3: Serials will use unique ID if possible
+    "xbox og interface",        // 4: xbox interface
+
+    // debugging strings.
+    "snek box debug", // 5: Product
+    "snek box cdc",   // 6: CDC Interface
+};
 
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void)
 {
+#if ENABLE_CDC_DEBUG
+    return (uint8_t const *)&desc_cdc_device;
+#else
     return (uint8_t const *)&xboxog_desc_device;
+#endif
 }
 
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
 {
     (void)index; // for multiple configurations
+
+#if ENABLE_CDC_DEBUG
+    return (uint8_t const *)&desc_fs_configuration;
+#else
     return (uint8_t const *)&xboxog_desc_fs_configuration;
+#endif
 }
 
 static uint16_t _desc_str[32 + 1];
+
+static inline size_t board_usb_get_serial_prefix(uint16_t desc_str1[], size_t max_chars, const char *prefix)
+{
+    size_t prefix_len = 0;
+    while (prefix[prefix_len] != '\0')
+    {
+        prefix_len++;
+    }
+
+    if (prefix_len * 2 >= max_chars)
+        return 0;
+
+    for (size_t i = 0; i < prefix_len; i++)
+    {
+        desc_str1[i] = prefix[i];
+    }
+
+    uint8_t uid[16] TU_ATTR_ALIGNED(4);
+    size_t uid_len;
+
+    pico_unique_board_id_t pico_id;
+    pico_get_unique_board_id(&pico_id);
+
+    size_t len = PICO_UNIQUE_BOARD_ID_SIZE_BYTES;
+    if (len > sizeof(uid))
+        len = sizeof(uid);
+
+    memcpy(uid, pico_id.id, len);
+    uid_len = len;
+
+    size_t remaining_chars = max_chars - prefix_len;
+    if (uid_len > remaining_chars / 2)
+        uid_len = remaining_chars / 2;
+
+    for (size_t i = 0; i < uid_len; i++)
+    {
+        for (size_t j = 0; j < 2; j++)
+        {
+            const char nibble_to_hex[16] = {
+                '0', '1', '2', '3', '4', '5', '6', '7',
+                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+            uint8_t const nibble = (uid[i] >> (j * 4)) & 0xf;
+            desc_str1[prefix_len + i * 2 + (1 - j)] = nibble_to_hex[nibble];
+        }
+    }
+
+    return 2 * uid_len + prefix_len;
+}
 
 uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 {
@@ -23,23 +151,24 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 
     switch (index)
     {
-    case STRID_XBOXOG_LANGID:
-        memcpy(&_desc_str[1], xboxog_string_desc_arr[0], 2);
+    case STRID_LANGID:
+        memcpy(&_desc_str[1], global_string_array[0], 2);
         chr_count = 1;
         break;
 
-        // case STRID_SERIAL:
-        // chr_count = board_usb_get_serial(_desc_str + 1, 32);
-        // break;
+    case STRID_SERIAL:
+        const char *prefix = "snek-";
+        chr_count = board_usb_get_serial_prefix(_desc_str + 1, 32, prefix);
+        break;
 
     default:
         // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-        if (index >= xboxog_string_desc_arr_len)
+        if (!(index < sizeof(global_string_array) / sizeof(global_string_array[0])))
             return NULL;
 
-        const char *str = xboxog_string_desc_arr[index];
+        const char *str = global_string_array[index];
 
         // Cap at max char
         chr_count = strlen(str);

--- a/targets/usb_descriptors.h
+++ b/targets/usb_descriptors.h
@@ -1,0 +1,15 @@
+#ifndef __USBDESC__H__
+#define __USBDESC__H__
+
+typedef enum {
+  STRID_LANGID = 0,
+  STRID_MANUFACTURER,
+  STRID_PRODUCT,
+  STRID_SERIAL,
+  STRID_XBOX_INTERFACE,
+  STRID_DEBUG_PRODUCT,
+  STRID_CDC_INTERFACE,
+  STRID_TOTAL
+} global_string_id;
+
+#endif

--- a/targets/xboxog_descriptors.c
+++ b/targets/xboxog_descriptors.c
@@ -1,18 +1,5 @@
 #include "xboxog_descriptors.h"
-
-// array of pointer to string descriptors
-char const *xboxog_string_desc_arr[] =
-    {
-        (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
-        "icedragon.io",             // 1: Manufacturer
-        "xbox og controller s",     // 2: Product
-        "snekbox",                  // 3: Serials will use unique ID if possible
-        "xbox og interface",
-};
-
-const size_t xboxog_string_desc_arr_len =
-    sizeof(xboxog_string_desc_arr) /
-    sizeof(xboxog_string_desc_arr[0]);
+#include "usb_descriptors.h"
 
 tusb_desc_device_t const xboxog_desc_device =
     {
@@ -31,9 +18,9 @@ tusb_desc_device_t const xboxog_desc_device =
         .idProduct = PID_XBOX_CTRL_S,
         .bcdDevice = 0x0120,
 
-        .iManufacturer = STRID_XBOXOG_MANUFACTURER,
-        .iProduct = STRID_XBOXOG_PRODUCT,
-        .iSerialNumber = STRID_XBOXOG_SERIAL,
+        .iManufacturer = STRID_MANUFACTURER,
+        .iProduct = STRID_PRODUCT,
+        .iSerialNumber = STRID_SERIAL,
 
         .bNumConfigurations = 1,
 };
@@ -60,7 +47,7 @@ const xboxog_cfg_desc_t xboxog_desc_fs_configuration = {
         .bInterfaceClass = XID_INTERFACE_CLASS,
         .bInterfaceSubClass = XID_INTERFACE_SUBCLASS,
         .bInterfaceProtocol = 0,
-        .iInterface = STRID_XBOXOG_INTERFACE,
+        .iInterface = STRID_XBOX_INTERFACE,
     },
     .xboxog_reportINEndpoint = {
         .bLength = sizeof(tusb_desc_endpoint_t),

--- a/targets/xboxog_descriptors.c
+++ b/targets/xboxog_descriptors.c
@@ -10,6 +10,10 @@ char const *xboxog_string_desc_arr[] =
         "xbox og interface",
 };
 
+const size_t xboxog_string_desc_arr_len =
+    sizeof(xboxog_string_desc_arr) /
+    sizeof(xboxog_string_desc_arr[0]);
+
 tusb_desc_device_t const xboxog_desc_device =
     {
         .bLength = sizeof(tusb_desc_device_t),
@@ -85,63 +89,3 @@ const xboxog_cfg_desc_t xboxog_desc_fs_configuration = {
         .bInterval = 0x04,
     },
 };
-
-// Invoked when received GET DEVICE DESCRIPTOR
-// Application return pointer to descriptor
-uint8_t const *tud_descriptor_device_cb(void)
-{
-    return (uint8_t const *)&xboxog_desc_device;
-}
-
-uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
-{
-    (void)index; // for multiple configurations
-    return (uint8_t const *)&xboxog_desc_fs_configuration;
-}
-
-static uint16_t _desc_str[32 + 1];
-
-uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
-{
-    (void)langid;
-    size_t chr_count;
-
-    switch (index)
-    {
-    case STRID_XBOXOG_LANGID:
-        memcpy(&_desc_str[1], xboxog_string_desc_arr[0], 2);
-        chr_count = 1;
-        break;
-
-        // case STRID_SERIAL:
-        // chr_count = board_usb_get_serial(_desc_str + 1, 32);
-        // break;
-
-    default:
-        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
-        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
-
-        if (!(index < sizeof(xboxog_string_desc_arr) / sizeof(xboxog_string_desc_arr[0])))
-            return NULL;
-
-        const char *str = xboxog_string_desc_arr[index];
-
-        // Cap at max char
-        chr_count = strlen(str);
-        size_t const max_count = sizeof(_desc_str) / sizeof(_desc_str[0]) - 1; // -1 for string type
-        if (chr_count > max_count)
-            chr_count = max_count;
-
-        // Convert ASCII string into UTF-16
-        for (size_t i = 0; i < chr_count; i++)
-        {
-            _desc_str[1 + i] = str[i];
-        }
-        break;
-    }
-
-    // first byte is length (including header), second byte is string type
-    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
-
-    return _desc_str;
-}

--- a/targets/xboxog_descriptors.h
+++ b/targets/xboxog_descriptors.h
@@ -27,16 +27,6 @@ enum InterfaceDescriptorsXBOX_t
     INTERFACE_ID_XBOX_Total
 };
 
-typedef enum
-{
-    STRID_XBOXOG_LANGID = 0,
-    STRID_XBOXOG_MANUFACTURER,
-    STRID_XBOXOG_PRODUCT,
-    STRID_XBOXOG_SERIAL,
-    STRID_XBOXOG_INTERFACE,
-    STRID_XBOXOG_TOTAL
-} xboxog_string_id_t;
-
 #pragma pack(push, 1)
 
 typedef struct TU_ATTR_PACKED
@@ -116,8 +106,6 @@ typedef struct
 
 #pragma pack(pop)
 
-extern char const *xboxog_string_desc_arr[];
-extern const size_t xboxog_string_desc_arr_len;
 extern tusb_desc_device_t const xboxog_desc_device;
 extern const xboxog_cfg_desc_t xboxog_desc_fs_configuration;
 

--- a/targets/xboxog_descriptors.h
+++ b/targets/xboxog_descriptors.h
@@ -116,4 +116,9 @@ typedef struct
 
 #pragma pack(pop)
 
+extern char const *xboxog_string_desc_arr[];
+extern const size_t xboxog_string_desc_arr_len;
+extern tusb_desc_device_t const xboxog_desc_device;
+extern const xboxog_cfg_desc_t xboxog_desc_fs_configuration;
+
 #endif

--- a/targets/xboxog_tusb_driver.c
+++ b/targets/xboxog_tusb_driver.c
@@ -176,9 +176,13 @@ static usbd_class_driver_t const _xboxogd_driver =
         .sof = NULL,
 };
 
+#if !(ENABLE_CDC_DEBUG)
+
 // Implement callback to add our custom driver
 usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count)
 {
     *driver_count = 1;
     return &_xboxogd_driver;
 }
+
+#endif

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -73,6 +73,17 @@ extern "C"
 #define CFG_TUD_ENDPOINT0_SIZE 64
 #endif
 
+#if (ENABLE_CDC_DEBUG)
+#define CFG_TUD_CDC 1
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE (CFG_TUD_ENDPOINT0_SIZE)
+#define CFG_TUD_CDC_TX_BUFSIZE (CFG_TUD_ENDPOINT0_SIZE)
+
+// CDC Endpoint transfer buffer size, more is faster
+#define CFG_TUD_CDC_EP_BUFSIZE (CFG_TUD_ENDPOINT0_SIZE)
+#endif
+
 //--------------------------------------------------------------------
 // HOST CONFIGURATION
 //--------------------------------------------------------------------


### PR DESCRIPTION
allows debugprintf to be diverted to a usb cdc device for remote debugging and troubleshooting.